### PR TITLE
Отключена проверка прав при поиске инфоблока в билдере.

### DIFF
--- a/lib/builder/iblockbuilder.php
+++ b/lib/builder/iblockbuilder.php
@@ -89,7 +89,7 @@ class IblockBuilder {
      * @throws BuilderException
      */
     public function updateIblock($id, $callback) {
-        $iblockData = \CIBlock::GetByID($id)->Fetch();
+        $iblockData = \CIBlock::GetList(array(), array('ID' => $id, 'CHECK_PERMISSIONS' => 'N'))->Fetch();
         if (!$iblockData) {
             throw new BuilderException("Iblock `{$id}` not found");
         }
@@ -210,6 +210,7 @@ class IblockBuilder {
         $dbRes = \CIBlock::GetList(null, array(
             'NAME' => $name,
             'TYPE' => $iblockType,
+            'CHECK_PERMISSIONS' => 'N',
         ));
         $count = $dbRes->SelectedRowsCount();
         if ($count == 0) {


### PR DESCRIPTION
По умолчанию метод \CIBlock::GetList() проверяет права доступа текущего пользователя к инфоблоку. Миграция из консоли выполняется от имени неавторизованного пользователя. Поэтому удаление и изменение инфоблока с использование билдера через консоль не сработают.