### PR TITLE
Устранение ошибки обращения к пустому свойству, когда оно пустое

### DIFF
--- a/lib/builder/entity/iblock.php
+++ b/lib/builder/entity/iblock.php
@@ -32,10 +32,10 @@ class Iblock  extends Base {
     const SECTION_CHOOSER_DROPDOWN = 'D';
     const SECTION_CHOOSER_SEARCH_WINDOW = 'P';
 
-    private $properties;
+    private $properties = [];
     private $id;
-    private $updateProperties;
-    private $deleteProperties;
+    private $updateProperties = [];
+    private $deleteProperties = [];
 
     const DEFAULT_SORT = 500;
 


### PR DESCRIPTION
В коде нет проверок на то что массив определен, тогда логично чтобы массив был определен по умолчанию, иначе получаем ворох ошибок уровня Warning
- В месте попытки добавления свойства не создается массив
- В месте перебора Invalid argument supplied for foreach